### PR TITLE
Fix yt-dlp http 403 error

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
-streamlit>=1.28.0
-yt-dlp>=2023.11.16
+streamlit>=1.32.0
+yt-dlp>=2024.08.06
 
 # Local transcription with Whisper (will install PyTorch and related packages)
 # Note: installing these on first deploy can be slow and large. Consider using a


### PR DESCRIPTION
Harden `yt-dlp` download options and update dependencies to resolve `HTTP Error 403: Forbidden` errors.

The `yt-dlp` options were configured for increased robustness, including forcing IPv4, adding retries, using alternative YouTube clients, and more realistic HTTP headers. Optional support for cookies and proxies via Streamlit secrets was also added to handle age/region-restricted content. Dependencies for `yt-dlp` and `streamlit` were updated to their latest versions.

---
<a href="https://cursor.com/background-agent?bcId=bc-0db848e0-3100-43d4-a09d-07e99cc2a835">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-0db848e0-3100-43d4-a09d-07e99cc2a835">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

