### PR TITLE
Debug yt-dlp http 403 error

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 streamlit>=1.32.0
-yt-dlp>=2024.08.06
+yt-dlp
 
 # Local transcription with Whisper (will install PyTorch and related packages)
 # Note: installing these on first deploy can be slow and large. Consider using a


### PR DESCRIPTION
Implement `yt-dlp` `player_client` fallback and unpin `yt-dlp` version to resolve YouTube 403 errors.

YouTube frequently updates its video serving mechanisms, leading to `HTTP Error 403: Forbidden` with `yt-dlp` in hosted environments like Streamlit Community Cloud. This change introduces a robust retry mechanism that cycles through different `player_client` types (`web`, `android`, `tv`) and ensures the latest `yt-dlp` version is always used, which often contains the most recent workarounds for these issues.

---
<a href="https://cursor.com/background-agent?bcId=bc-20279f16-af78-4cc4-a814-817183de5339">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-20279f16-af78-4cc4-a814-817183de5339">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

