### PR TITLE
Fix youtube 403 errors without sign in

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -12,6 +12,10 @@ soundfile>=0.12.1
 ffmpeg-python>=0.2.0
 python-dotenv>=1.0.0
 
+# Fetch captions without media download and perform simple HTTP requests
+youtube-transcript-api>=0.6.2
+requests>=2.31.0
+
 # Optional: add `openai` if you later want cloud fallback
 # openai>=1.0.0
  


### PR DESCRIPTION
Implement transcript-first YouTube summarization to avoid 403 errors and improve performance.

This change prioritizes fetching captions via `youtube-transcript-api` and video titles via YouTube oEmbed, eliminating the need for `yt-dlp` downloads and associated authentication issues (HTTP 403 Forbidden). An optional, user-controlled Whisper fallback is provided for videos without available captions, ensuring a fast default experience and resolving the recurring sign-in prompts.

---
<a href="https://cursor.com/background-agent?bcId=bc-86390b78-f46b-4433-b4f7-9f7f37ad65d8">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-86390b78-f46b-4433-b4f7-9f7f37ad65d8">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

