### PR TITLE
Integrate rapidapi for youtube downloads

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ The application will open in your default web browser at `http://localhost:8501`
 ### Architecture
 
 - **Frontend**: Streamlit for responsive web UI
-- **Video Download**: pytubefix (enhanced pytube fork) and RapidAPI
+- **Video Download**: RapidAPI for reliable cloud-based downloads
 - **Transcription**: OpenAI Whisper model
 - **Summarization**: Qwen Coder CLI assistant with contextual prompts
 - **Audio Processing**: FFmpeg for format conversion
@@ -176,7 +176,6 @@ Create a clear, comprehensive summary that captures the main points, key informa
 This project is open source. Please check individual tool licenses:
 - OpenAI Whisper: MIT License
 - Qwen Coder: Free to use (check Qwen Coder license)
-- pytubefix: MIT License
 - Streamlit: Apache 2.0 License
 
 ## 🤝 Contributing

--- a/README_403_FIX.md
+++ b/README_403_FIX.md
@@ -18,8 +18,8 @@ rapidapi_key = "your-api-key-here"
 
 Note: Free tier has limited requests per month, but it's a reliable solution for cloud deployments.
 
-### 2. Use a Proxy Server
-If pytubefix is getting blocked, you can route requests through a proxy:
+### 2. Use a Proxy Server (Optional)
+If you need to route requests through a proxy:
 
 ```toml
 proxy_url = "http://proxy-server:port"
@@ -39,15 +39,11 @@ If you need unlimited downloads, consider deploying on:
 
 The app now uses a simplified approach focused on reliability:
 
-1. **Primary Method**: pytubefix - An enhanced fork of pytube with:
-   - Better error handling
-   - Proxy support
-   - More robust against YouTube changes
-   - Anti-bot detection measures
-
-2. **Fallback Method**: RapidAPI YouTube MP3 service
-   - Bypasses direct YouTube access
-   - Works reliably on cloud platforms
+1. **Single Method**: RapidAPI YouTube MP3 service
+   - Works consistently on cloud platforms
+   - Bypasses YouTube's bot detection
+   - Provides stable downloads
+   - No direct YouTube access needed
    - Requires API key but offers stable service
 
 ## Configuration in Streamlit Secrets

--- a/STREAMLIT_DEPLOYMENT.md
+++ b/STREAMLIT_DEPLOYMENT.md
@@ -32,16 +32,15 @@ proxy_url = "http://your-proxy-server:port"
 
 ## How It Works
 
-The app uses two methods to download YouTube videos:
+The app uses RapidAPI to download YouTube videos:
 
-1. **pytubefix** (Primary): Direct download when possible
-2. **RapidAPI** (Fallback): Cloud-friendly API service
+**RapidAPI**: Cloud-friendly API service for reliable YouTube downloads
 
-When deployed on Streamlit Community Cloud, YouTube often blocks direct downloads. The RapidAPI fallback ensures your app continues working reliably.
+When deployed on Streamlit Community Cloud, YouTube often blocks direct downloads. RapidAPI ensures your app continues working reliably in cloud environments.
 
 ## Troubleshooting
 
-### Error: "Neither pytubefix nor RapidAPI key is available"
+### Error: "RapidAPI key is not configured"
 - Make sure you've added the `rapidapi_key` in your Streamlit secrets
 - Check that the key is valid and has remaining quota
 

--- a/YOUTUBE_ERROR_FIX_SUMMARY.md
+++ b/YOUTUBE_ERROR_FIX_SUMMARY.md
@@ -5,16 +5,10 @@ Streamlit Community Cloud was experiencing "Sign in to confirm you're not a bot"
 
 ## Solutions Implemented
 
-### 1. **Multiple Download Methods**
-- Replaced `yt-dlp` with `pytubefix` as the primary download method
-- Implemented multiple player client fallbacks including:
-  - web_creator
-  - android_creator
-  - ios
-  - web_embedded
-  - android_embedded
-  - mweb (mobile web)
-  - tv_embedded
+### 1. **Reliable Download Method**
+- Uses RapidAPI as the sole download method for reliability
+- Cloud-friendly solution that works on all platforms
+- No need for complex fallback mechanisms or player client workarounds
 
 ### 2. **Enhanced Bot Detection Avoidance**
 - Added random delays between requests (1-5 seconds)
@@ -35,14 +29,15 @@ Streamlit Community Cloud was experiencing "Sign in to confirm you're not a bot"
 - Example videos from channels that rarely get blocked
 - Better feedback during the download process
 
-### 5. **Fallback Strategies**
-- Primary: Use transcript API (no download needed)
-- Primary: pytubefix with anti-detection measures
-- Secondary: RapidAPI YouTube MP3 service
+### 5. **Simplified Strategy**
+- Single reliable method: RapidAPI YouTube MP3 service
+- No complex fallback chains needed
+- Consistent behavior across all deployment environments
 
 ## Configuration Changes
-- Added `pytube>=15.0.0` to requirements.txt
-- Prepared infrastructure for potential invidious instance usage
+- Removed pytubefix dependency from requirements.txt
+- Streamlined configuration to use only RapidAPI key
+- Simplified deployment process
 
 ## Best Practices for Users
 1. Prefer videos with captions/subtitles (no download needed)

--- a/context.md
+++ b/context.md
@@ -5,7 +5,7 @@ A Streamlit application that automatically summarizes YouTube videos using AI.
 ## Features
 
 - **Easy Input**: Users can paste YouTube video links directly into the UI
-- **Automated Processing**: Downloads videos using pytubefix and RapidAPI
+- **Automated Processing**: Downloads videos using RapidAPI for reliable cloud performance
 - **AI Transcription**: Uses Whisper model to convert speech to text
 - **Smart Summarization**: Leverages Qwen Coder CLI assistant to generate concise summaries
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,5 @@
 streamlit>=1.32.0
 requests>=2.31.0
-pytubefix>=6.0.0  # Enhanced pytube fork with better error handling
 
 # Whisper for transcription
 openai-whisper>=20231117


### PR DESCRIPTION
Migrate YouTube video downloads to exclusively use RapidAPI, removing pytubefix for improved cloud reliability and a simplified codebase.

---
<a href="https://cursor.com/background-agent?bcId=bc-40c2c0bd-94c8-4a33-a6ce-59e11c025925">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-40c2c0bd-94c8-4a33-a6ce-59e11c025925">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

